### PR TITLE
feat: add --omit-url

### DIFF
--- a/src/site_scout/args.py
+++ b/src/site_scout/args.py
@@ -109,11 +109,10 @@ def parse_args(argv: list[str] | None = None) -> Namespace:
         help="Browser memory limit in MBs (default: no limit).",
     )
     parser.add_argument(
-        "--prefs",
-        type=Path,
-        help="Custom prefs.js file to use (default: generated).",
+        "--omit-urls",
+        action="store_true",
+        help="Do not include URLs in saved results (default: %(default)s).",
     )
-    parser.add_argument("--profile", type=Path, help="")
     parser.add_argument(
         "-o",
         "--output-path",
@@ -121,6 +120,12 @@ def parse_args(argv: list[str] | None = None) -> Namespace:
         type=Path,
         help="Location to save results (default: %(default)s).",
     )
+    parser.add_argument(
+        "--prefs",
+        type=Path,
+        help="Custom prefs.js file to use (default: generated).",
+    )
+    parser.add_argument("--profile", type=Path)
     parser.add_argument(
         "--result-limit",
         type=int,

--- a/src/site_scout/explorer.py
+++ b/src/site_scout/explorer.py
@@ -178,7 +178,7 @@ class Explorer:
                     return
                 url_loaded = explorer.current_url
                 load_duration = perf_counter() - start_time
-                LOG.debug("loaded: %r (%r)", title, url_loaded)
+                LOG.debug("loaded in %0.1fs: %r (%r)", load_duration, title, url_loaded)
                 # wait for more content to load/render
                 can_skip.wait(timeout=LOAD_WAIT)
                 # attempt to find and activate "skip to content" link

--- a/src/site_scout/main.py
+++ b/src/site_scout/main.py
@@ -140,6 +140,7 @@ def main(argv: list[str] | None = None) -> int:
             fuzzmanager=args.fuzzmanager,
             coverage=args.coverage,
             explore=args.explore,
+            omit_urls=args.omit_urls,
         ) as scout:
             LOG.info("Loading URLs...")
             for data in load_input(args.input):

--- a/src/site_scout/url.py
+++ b/src/site_scout/url.py
@@ -30,7 +30,7 @@ class URL:
     VALID_DOMAIN = re_compile(r"[a-zA-Z0-9:.-]+")
     VALID_SUBDOMAIN = re_compile(r"[a-zA-Z0-9_.-]+")
 
-    __slots__ = ("_uid", "domain", "path", "scheme", "subdomain")
+    __slots__ = ("_uid", "alias", "domain", "path", "scheme", "subdomain")
 
     def __init__(
         self,
@@ -39,6 +39,7 @@ class URL:
         path: str = "/",
         scheme: str = "http",
     ) -> None:
+        self.alias: str | None = None
         self.domain = domain
         self.path = path
         self.scheme = scheme


### PR DESCRIPTION
Report alias instead of URL when reporting results. By default alias is None which will fallback to the URL. When --omit-url is set the default alias is set to "REDACTED".